### PR TITLE
Subscribers paginated and bundeled demographic data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "http://rubygems.org"
 # Example:
 #   gem "activesupport", ">= 2.3.5"
 
-gem "http2", "~> 0.0.28"
+gem "http2", "~> 0.0.31"
 gem "string-cases"
 gem "tretry", "0.0.2"
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "http://rubygems.org"
 # Example:
 #   gem "activesupport", ">= 2.3.5"
 
-gem "http2", "~> 0.0.25"
+gem "http2", "~> 0.0.28"
 gem "string-cases"
 gem "tretry", "0.0.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,9 +59,12 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (>= 1.0.0)
-  http2 (~> 0.0.28)
+  http2 (~> 0.0.31)
   jeweler (~> 1.8.4)
   rdoc (~> 3.12)
   rspec (~> 2.8.0)
   string-cases
   tretry (= 0.0.2)
+
+BUNDLED WITH
+   1.10.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
       oauth2
     hashie (3.2.0)
     highline (1.6.21)
-    http2 (0.0.25)
+    http2 (0.0.28)
       string-cases
     jeweler (1.8.8)
       builder
@@ -59,7 +59,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (>= 1.0.0)
-  http2 (~> 0.0.25)
+  http2 (~> 0.0.28)
   jeweler (~> 1.8.4)
   rdoc (~> 3.12)
   rspec (~> 2.8.0)

--- a/README.md
+++ b/README.md
@@ -98,6 +98,20 @@ aos.subscribers do |sub|
 end
 ```
 
+### Bundle various field names in same request
+```ruby
+aos.subscribers(field_names: ["MyData1", "MyData2"]) do |sub|
+  # do something
+end
+```
+
+### Bundle all data in same request
+```ruby
+aos.subscribers(all_demographics: true) do |sub|
+  # do something
+end
+```
+
 ### Get sendings
 ```ruby
 date_from = Date.new(2014, 6, 17)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ aos.subscribers do |sub|
 end
 ```
 
-### Bundle various field names in same request
+### Bundle various field names in same request (which means they are already preloaded and won't cause an extra request each time you ask for the fields)
 ```ruby
 aos.subscribers(field_names: ["MyData1", "MyData2"]) do |sub|
   # do something

--- a/include/mailing_list.rb
+++ b/include/mailing_list.rb
@@ -36,7 +36,7 @@ class ApsisOnSteroids::MailingList < ApsisOnSteroids::SubBase
     allow_paginated = args.key?(:allow_paginated) ? args[:allow_paginated] : true
 
     # Abort and do paginated if no reason to get everything as JSON.
-    if allow_paginated && !all_demographic && field_names.empty?
+    if allow_paginated && !all_demographics && field_names.empty?
       return subscribers_paginated(&blk)
     end
 
@@ -72,7 +72,7 @@ class ApsisOnSteroids::MailingList < ApsisOnSteroids::SubBase
         data: aos.parse_obj(sub_data)
       )
 
-      if all_demographics || !fields.empty?
+      if all_demographics || !field_names.empty?
         sub.instance_variable_set(:@dem_data_fields, sub_data["DemographicData"])
       end
 

--- a/include/mailing_list.rb
+++ b/include/mailing_list.rb
@@ -72,8 +72,6 @@ class ApsisOnSteroids::MailingList < ApsisOnSteroids::SubBase
         data: aos.parse_obj(sub_data)
       )
 
-      puts "SubData: #{sub_data}"
-
       if all_demographics || !fields.empty?
         sub.instance_variable_set(:@dem_data_fields, sub_data["DemographicData"])
       end

--- a/include/mailing_list.rb
+++ b/include/mailing_list.rb
@@ -29,7 +29,12 @@ class ApsisOnSteroids::MailingList < ApsisOnSteroids::SubBase
   end
 
   # Returns the subscribers of the mailing list.
+  SUBSCRIBERS_VALID_ARGS = [:all_demographics, :timeout, :field_names, :allow_paginated]
   def subscribers(args = {}, &blk)
+    args.each do |key, value|
+      raise "Invalid argument: '#{key}'." unless SUBSCRIBERS_VALID_ARGS.include?(key)
+    end
+
     all_demographics = args.key?(:all_demographics) ? args[:all_demographics] : false
     timeout = args[:timeout] || 300
     field_names = args[:field_names] || []

--- a/include/mailing_list.rb
+++ b/include/mailing_list.rb
@@ -28,8 +28,9 @@ class ApsisOnSteroids::MailingList < ApsisOnSteroids::SubBase
     data_subscribers
   end
 
-  # Returns the subscribers of the mailing list.
   SUBSCRIBERS_VALID_ARGS = [:all_demographics, :timeout, :field_names, :allow_paginated]
+
+  # Returns the subscribers of the mailing list.
   def subscribers(args = {}, &blk)
     args.each do |key, value|
       raise "Invalid argument: '#{key}'." unless SUBSCRIBERS_VALID_ARGS.include?(key)

--- a/include/mailing_list.rb
+++ b/include/mailing_list.rb
@@ -29,16 +29,26 @@ class ApsisOnSteroids::MailingList < ApsisOnSteroids::SubBase
   end
 
   # Returns the subscribers of the mailing list.
-  def subscribers
+  def subscribers(args = {}, &blk)
+    all_demographics = args.key?(:all_demographics) ? args[:all_demographics] : false
+    timeout = args[:timeout] || 300
+    field_names = args[:field_names] || []
+    allow_paginated = args.key?(:allow_paginated) ? args[:allow_paginated] : true
+
+    # Abort and do paginated if no reason to get everything as JSON.
+    if allow_paginated && !all_demographic && field_names.empty?
+      return subscribers_paginated(&blk)
+    end
+
     res = aos.req_json("v1/mailinglists/#{data(:id)}/subscribers/all", :post, json: {
-      "AllDemographics" => false,
-      "FieldNames" => []
+      "AllDemographics" => all_demographics,
+      "FieldNames" => field_names
     })
 
     url = URI.parse(res["Result"]["PollURL"])
     data_subscribers = nil
 
-    Timeout.timeout(300) do
+    Timeout.timeout(timeout) do
       loop do
         sleep 1
         res = aos.req_json(url.path)
@@ -57,6 +67,33 @@ class ApsisOnSteroids::MailingList < ApsisOnSteroids::SubBase
 
     ret = []
     data_subscribers.each do |sub_data|
+      sub = ApsisOnSteroids::Subscriber.new(
+        aos: self.aos,
+        data: aos.parse_obj(sub_data)
+      )
+
+      puts "SubData: #{sub_data}"
+
+      if all_demographics || !fields.empty?
+        sub.instance_variable_set(:@dem_data_fields, sub_data["DemographicData"])
+      end
+
+      if blk
+        blk.call(sub)
+      else
+        ret << sub
+      end
+    end
+
+    return ret
+  end
+
+  # Returns the subscribers of the mailing list.
+  def subscribers_paginated
+    resource_url = "v1/mailinglists/#{data(:id)}/subscribers/%{page}/%{size}"
+
+    ret = []
+    aos.read_paginated_response(resource_url) do |sub_data|
       sub = ApsisOnSteroids::Subscriber.new(
         aos: self.aos,
         data: aos.parse_obj(sub_data)

--- a/include/open.rb
+++ b/include/open.rb
@@ -1,3 +1,2 @@
 class ApsisOnSteroids::Open < ApsisOnSteroids::SubBase
-
 end

--- a/include/opt_out.rb
+++ b/include/opt_out.rb
@@ -1,3 +1,2 @@
 class ApsisOnSteroids::OptOut < ApsisOnSteroids::SubBase
-
 end

--- a/include/sending.rb
+++ b/include/sending.rb
@@ -1,17 +1,17 @@
 class ApsisOnSteroids::Sending < ApsisOnSteroids::SubBase
-  def clicks args = {}
+  def clicks(args = {})
     list_for("v1/clicks/sendqueues/%{send_queue_id}/page/%{page}/size/%{size}", "v1/sendqueues/%{send_queue_id}/clicks", "Click", args)
   end
 
-  def opens args = {}
+  def opens(args = {})
     list_for("v1/opens/sendqueues/%{send_queue_id}/page/%{page}/size/%{size}", "v1/sendqueues/%{send_queue_id}/opens", "Open", args)
   end
 
-  def bounces args = {}
+  def bounces(args = {})
     list_for("v1/bounces/sendqueues/%{send_queue_id}/page/%{page}/size/%{size}", "v1/sendqueues/%{send_queue_id}/bounces", "Bounce", args)
   end
 
-  def opt_outs args = {}
+  def opt_outs(args = {})
     list_for("v1/optouts/sendqueues/%{send_queue_id}/%{page}/%{size}", "v1/sendqueues/%{send_queue_id}/optouts", "OptOut", args)
   end
 
@@ -26,7 +26,7 @@ class ApsisOnSteroids::Sending < ApsisOnSteroids::SubBase
 
 private
 
-  def list_for_with_dates resource_url, resource_name, args
+  def list_for_with_dates(resource_url, resource_name, args)
     resource_url = resource_url.gsub("%{send_queue_id}", data(:send_queue_id).to_s)
 
     ub = aos.new_url_builder
@@ -48,7 +48,7 @@ private
     end
   end
 
-  def list_for resource_url, resource_url_with_dates, resource_name, args = {}
+  def list_for(resource_url, resource_url_with_dates, resource_name, args = {})
     # OptOut counting does not work :-( We will have to do the date request to fix this...
     # If date-arguments are given, we will have to use the date request.
     if args[:date_from] || args[:date_to] || resource_name == "OptOut"

--- a/include/subscriber.rb
+++ b/include/subscriber.rb
@@ -1,7 +1,7 @@
 class ApsisOnSteroids::Subscriber < ApsisOnSteroids::SubBase
   # Fetches the details from the server and returns them.
   def details
-    if !@details
+    unless @details
       res = aos.req_json("v1/subscribers/id/#{data(:id)}")
 
       ret = {}
@@ -19,18 +19,19 @@ class ApsisOnSteroids::Subscriber < ApsisOnSteroids::SubBase
   def dem_data(key)
     key = key.to_s.downcase
 
-    self.details[:DemDataFields].each do |dem_data|
-      if dem_data["Key"].to_s.downcase == key
-        return dem_data["Value"]
-      end
+    dem_data_fields.each do |dem_data|
+      return dem_data["Value"] if dem_data["Key"].to_s.downcase == key
     end
 
     return nil
   end
 
+  def dem_data_fields
+    @dem_data_fields ||= details[:DemDataFields]
+  end
+
   # Returns true if the subscriber is active.
   def active?
-    details = self.details
     return false if details[:pending]
     return true
   end

--- a/lib/apsis-on-steroids.rb
+++ b/lib/apsis-on-steroids.rb
@@ -199,8 +199,6 @@ class ApsisOnSteroids
       resource_url_to_use = resource_url.gsub("%{page}", page.to_s)
       result = aos.req_json(resource_url_to_use)
 
-      puts "Res: #{result}"
-
       result["Result"]["Items"].each do |resource_data|
         yield resource_data
       end

--- a/lib/apsis-on-steroids.rb
+++ b/lib/apsis-on-steroids.rb
@@ -197,7 +197,7 @@ class ApsisOnSteroids
 
     loop do
       resource_url_to_use = resource_url.gsub("%{page}", page.to_s)
-      result = aos.req_json(resource_url_to_use)
+      result = req_json(resource_url_to_use)
 
       result["Result"]["Items"].each do |resource_data|
         yield resource_data

--- a/lib/apsis-on-steroids.rb
+++ b/lib/apsis-on-steroids.rb
@@ -191,6 +191,29 @@ class ApsisOnSteroids
     end
   end
 
+  def read_paginated_response(resource_url)
+    page = 1
+    resource_url = resource_url.gsub("%{size}", "1000")
+
+    loop do
+      resource_url_to_use = resource_url.gsub("%{page}", page.to_s)
+      result = aos.req_json(resource_url_to_use)
+
+      puts "Res: #{result}"
+
+      result["Result"]["Items"].each do |resource_data|
+        yield resource_data
+      end
+
+      size_no = result["Result"]["TotalPages"]
+      if page >= size_no
+        break
+      else
+        page += 1
+      end
+    end
+  end
+
   def parse_obj(obj)
     if obj.is_a?(Array)
       ret = []

--- a/lib/apsis-on-steroids.rb
+++ b/lib/apsis-on-steroids.rb
@@ -252,6 +252,7 @@ private
       host: "se.api.anpdm.com",
       port: 8443,
       ssl: true,
+      ssl_skip_verify: true,
       follow_redirects: false,
       debug: @args[:debug],
       extra_headers: {

--- a/spec/apsis-on-steroids_spec.rb
+++ b/spec/apsis-on-steroids_spec.rb
@@ -110,12 +110,48 @@ describe "ApsisOnSteroids" do
       original_sub = sub
 
       count = 0
-      mlist.subscribers do |sub_i|
+      mlist.subscribers(allow_paginated: false) do |sub_i|
         count += 1
         #puts "Subscriber: #{sub_i}"
       end
 
-      raise "Expected more than one." if count < 1
+      count.should > 0
+    end
+
+    it "should include demographics data when set" do
+      original_sub = sub
+
+      count = 0
+      mlist.subscribers(all_demographics: true) do |sub_i|
+        count += 1
+        sub_i.instance_variable_get(:@dem_data_fields).should_not eq nil
+      end
+
+      count.should > 0
+    end
+
+    it "should include optional fields as demographic data when set" do
+      original_sub = sub
+
+      count = 0
+      mlist.subscribers(fields: ["NaoshiID"]) do |sub_i|
+        count += 1
+        sub_i.instance_variable_get(:@dem_data_fields).should eq [{"Key" => "NaoshiID", "Value" => ""}]
+      end
+
+      count.should > 0
+    end
+
+    it "should get subscribers paginated" do
+      original_sub = sub
+
+      count = 0
+      mlist.subscribers_paginated do |sub_i|
+        count += 1
+        #puts "Subscriber: #{sub_i}"
+      end
+
+      count.should > 0
     end
 
     it "can remove subscribers from lists" do

--- a/spec/apsis-on-steroids_spec.rb
+++ b/spec/apsis-on-steroids_spec.rb
@@ -150,7 +150,6 @@ describe "ApsisOnSteroids" do
       count = 0
       mlist.subscribers_paginated do |sub_i|
         count += 1
-        #puts "Subscriber: #{sub_i}"
       end
 
       count.should > 0

--- a/spec/apsis-on-steroids_spec.rb
+++ b/spec/apsis-on-steroids_spec.rb
@@ -134,7 +134,7 @@ describe "ApsisOnSteroids" do
       original_sub = sub
 
       count = 0
-      mlist.subscribers(fields: ["NaoshiID"]) do |sub_i|
+      mlist.subscribers(field_names: ["NaoshiID"]) do |sub_i|
         count += 1
         sub_i.instance_variable_get(:@dem_data_fields).should eq [{"Key" => "NaoshiID", "Value" => ""}]
       end


### PR DESCRIPTION
Asana: https://app.asana.com/0/7005399303210/16381172566150
Task: https://tasks.kaspernj.org/tasks/1404

Still some work to be done (think I blocked the queue, and I must wait for it to finish before continuing).

- [x] Check that fields-argument actually work.
- [x] Check that paginated subscribers actually work.

Various work on paginated subscribers to spare memory and bundle demographic data to avoid fetching it one by one.

Fixed method definition standards.
Custom timeout for subscribers (this request might take a long time to generate for Apsis).