### PR TITLE
Fixes spec error if date not loaded

### DIFF
--- a/spec/apsis-on-steroids_spec.rb
+++ b/spec/apsis-on-steroids_spec.rb
@@ -33,6 +33,8 @@ describe "ApsisOnSteroids" do
   end
 
   it "#sendings_by_date_interval" do
+    require 'date'
+
     date_from = Date.new(2013, 4, 1)
     date_to = Date.new(2013, 6, 2)
 


### PR DESCRIPTION
When `date` is not loaded by default, this triggers an `wrong number of arguments(3 for 0)` exception.

Ensure `date` is present in the particular test.