### PR TITLE
Disable http2-raise_errors to expose Apsis errors

### DIFF
--- a/lib/apsis-on-steroids.rb
+++ b/lib/apsis-on-steroids.rb
@@ -262,7 +262,8 @@ private
         user: @args[:api_key],
         passwd: ""
       },
-      skip_port_in_host_header: true
+      skip_port_in_host_header: true,
+      raise_errors: false
     )
   end
 end


### PR DESCRIPTION
As Apsis sends back "500 Internal Server Error" in cases like trying to subscribe a subscriber already existing on a mailinglist (error `Failed because there is already a subscription on this mailinglist for this subscriber`), this message gets lost due to not being passed on as default.

By disabling `raise_errors` making `http2` not running `handle_errors`, will pass all http errors as expected back to the project using the gem as expected, making it possible to take action - instead of the more generic and rather anonymous "500 Internal Server Error".

As this have worked as expected before, and neither `http2` nor `apsis-on-steroids` seems to have changed in this area, it could seem like `Apsis API` has started returning different http-codes depending on situation, than previously.

[Documentation](http://se.apidoc.anpdm.com/Help/QueuedMethods/About%20queued%20methods) also state `Check either the HTTP Status Code in the response or the "code" in the response body to see if all went OK or if there was an error.` which make it most likely affecting other codes than just 500 too (hence 400, 403 or 404, which `http2` currently throws).

The full response from the server looks like this:
```
HTTP/1.1 500 Internal Server Error
Cache-Control: private
Content-Length: 121
Content-Type: application/json; charset=utf-8
Server: [...]
Date: [...]

{"Code":-1,"Message":"Failed because there is already a subscription on this mailinglist for this subscriber","Result":0}
```